### PR TITLE
Reset skippedRows array in clear method

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
+++ b/app/code/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
@@ -325,6 +325,7 @@ class ProcessingErrorAggregator implements ProcessingErrorAggregatorInterface
         $this->items = [];
         $this->errorStatistics = [];
         $this->invalidRows = [];
+        $this->skippedRows = [];
 
         return $this;
     }


### PR DESCRIPTION
Added skippedRows array in clear method, missing to clear this array can cause an issue when you programmatically import more than one file, especially in a foreach loop because this object is treated as singleton. In this case, in the next file of your loop, magento checks for skipped rows and skips rows based on previous file. A pseudo-code example is following:

`$files = ['file1.csv', 'file2.csv'];`

`foreach ($files as $file) {`
`    .... // validate file`
`    .... // import file`
`    // if some file has skipped rows, skippedRows array is persistent between all files because is not cleared with clear() method called in validateData() method`
`}`